### PR TITLE
fix travis jdk version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # .travis.yml
 language: java
+jdk: oraclejdk8
 before_script: cd Platforms/Java
 script: ./gradlew test check


### PR DESCRIPTION
#13 has problem with compile.

Default travis java version is 1.7. 
But IotLab's target version is 1.8.
